### PR TITLE
Remove references to `edit_only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ time until only those whitelisted remain. It allows you to maintain your normal 
 scrubbed after a certain amount of time.
 
 When it became known that post edits were *not* saved but post deletions *were* saved, code was added to edit your post
-prior to deletion. In fact you can actually turn off deletion all together and just have lorem ipsum (or a message
-about Shreddit) but this will increase how long it takes the script to run as it will be going over all of your messages
-every run.
+prior to deletion.
 
 ## Important New Changes (as of Dec 2016)
 

--- a/shreddit/__init__.py
+++ b/shreddit/__init__.py
@@ -18,5 +18,4 @@ default_config = {"username": None,
                   "trial_run": False,
                   "clear_vote": False,
                   "replacement_format": "random",
-                  "edit_only": False,
                   "batch_cooldown": 10}


### PR DESCRIPTION
I merged all of the forks to see if any had missed commits and found dc654b2, to which I added e568672. It looked like you were doing a lot of cleanup work recently so here's a PR in case you're interested, no worries if not. Cheers and be well.